### PR TITLE
Avoid a "Trying to access array offset on value of type bool" warning

### DIFF
--- a/inc/class-my-photon.php
+++ b/inc/class-my-photon.php
@@ -370,15 +370,16 @@ class My_Photon {
 						$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 						if ( is_array( $image_meta ) ) {
-							$smaller_width  = ( ( $image_meta['width']  < $image_args['width']  ) ? $image_meta['width']  : $image_args['width'] );
+							$smaller_width  = ( ( $image_meta['width'] < $image_args['width'] ) ? $image_meta['width'] : $image_args['width'] );
 							$smaller_height = ( ( $image_meta['height'] < $image_args['height'] ) ? $image_meta['height'] : $image_args['height'] );
 
 							$photon_args[ $transform ] = $smaller_width . ',' . $smaller_height;
+						} else {
+							$photon_args[ $transform ] = $image_args['width'] . ',' . $image_args['height'];
 						}
 					} else {
 						$photon_args[ $transform ] = $image_args['width'] . ',' . $image_args['height'];
 					}
-
 				}
 
 				$photon_args = apply_filters( 'my_photon_image_downsize_string', $photon_args, compact( 'image_args', 'image_url', 'attachment_id', 'size', 'transform' ) );

--- a/inc/class-my-photon.php
+++ b/inc/class-my-photon.php
@@ -366,13 +366,15 @@ class My_Photon {
 						$photon_args['w'] = $image_args['width'];
 				} else {
 					if( 'resize' == $transform ) {
-						// Lets make sure that we don't upscale images since wp never upscales them as well
+						// Lets make sure that we don't upscale images since wp never upscales them as well.
 						$image_meta = wp_get_attachment_metadata( $attachment_id );
 
-						$smaller_width  = ( ( $image_meta['width']  < $image_args['width']  ) ? $image_meta['width']  : $image_args['width']  );
-						$smaller_height = ( ( $image_meta['height'] < $image_args['height'] ) ? $image_meta['height'] : $image_args['height'] );
+						if ( is_array( $image_meta ) ) {
+							$smaller_width  = ( ( $image_meta['width']  < $image_args['width']  ) ? $image_meta['width']  : $image_args['width'] );
+							$smaller_height = ( ( $image_meta['height'] < $image_args['height'] ) ? $image_meta['height'] : $image_args['height'] );
 
-						$photon_args[ $transform ] = $smaller_width . ',' . $smaller_height;
+							$photon_args[ $transform ] = $smaller_width . ',' . $smaller_height;
+						}
 					} else {
 						$photon_args[ $transform ] = $image_args['width'] . ',' . $image_args['height'];
 					}

--- a/inc/class-my-photon.php
+++ b/inc/class-my-photon.php
@@ -355,27 +355,25 @@ class My_Photon {
 					}
 				}
 
-				// Expose determined arguments to a filter before passing to Photon
+				// Expose determined arguments to a filter before passing to Photon.
 				$transform = $image_args['crop'] ? 'resize' : 'fit';
 
 				// Check specified image dimensions and account for possible zero values; photon fails to resize if a dimension is zero.
-				if ( 0 == $image_args['width'] || 0 == $image_args['height'] ) {
-					if ( 0 == $image_args['width'] && 0 < $image_args['height'] )
+				if ( 0 === $image_args['width'] || 0 === $image_args['height'] ) {
+					if ( 0 === $image_args['width'] && 0 < $image_args['height'] ) {
 						$photon_args['h'] = $image_args['height'];
-					elseif ( 0 == $image_args['height'] && 0 < $image_args['width'] )
+					} elseif ( 0 === $image_args['height'] && 0 < $image_args['width'] ) {
 						$photon_args['w'] = $image_args['width'];
+					}
 				} else {
-					if( 'resize' == $transform ) {
-						// Lets make sure that we don't upscale images since wp never upscales them as well.
-						$image_meta = wp_get_attachment_metadata( $attachment_id );
-
-						if ( is_array( $image_meta ) ) {
+					$image_meta = wp_get_attachment_metadata( $attachment_id );
+					if ( ( 'resize' === $transform ) && $image_meta ) {
+						if ( isset( $image_meta['width'], $image_meta['height'] ) ) {
+							// Lets make sure that we don't upscale images since wp never upscales them as well.
 							$smaller_width  = ( ( $image_meta['width'] < $image_args['width'] ) ? $image_meta['width'] : $image_args['width'] );
 							$smaller_height = ( ( $image_meta['height'] < $image_args['height'] ) ? $image_meta['height'] : $image_args['height'] );
 
 							$photon_args[ $transform ] = $smaller_width . ',' . $smaller_height;
-						} else {
-							$photon_args[ $transform ] = $image_args['width'] . ',' . $image_args['height'];
 						}
 					} else {
 						$photon_args[ $transform ] = $image_args['width'] . ',' . $image_args['height'];


### PR DESCRIPTION
If an image has no metadata, one can get flooded with this warning:

> Warning: Trying to access array offset on value of type bool in /var/www/site/wp-content/plugins/my-photon/inc/class-my-photon.php on line 372